### PR TITLE
Add limit to SPRT test

### DIFF
--- a/server.js
+++ b/server.js
@@ -233,8 +233,8 @@ function LLR(W, L, elo0, elo1) {
     return (s1-s0)*(2*s-s0-s1)/variance_s/2.0;
 }
 
-//function SPRT(W,L,elo0,elo1)
-function SPRT(W,L)
+//function SPRTold(W,L,elo0,elo1)
+function SPRTold(W,L)
 {
     var elo0 = 0, elo1 = 35;
     var alpha = .05, beta = .05;
@@ -250,6 +250,25 @@ function SPRT(W,L)
     } else {
         return null;
     }
+}
+
+function stDev(n) {
+  return Math.sqrt(Math.pow(n/2,2)/n);
+}
+
+function canReachLimit(w, l, max, aim) {
+  var aimPerc = aim/max;
+  var remaining = max-w-l;
+  var expected = remaining*aimPerc;
+  var maxExpected = expected+3*stDev(remaining)
+  var needed = aim-w;
+  return maxExpected>needed;
+}
+
+function SPRT(w, l) {
+  if(w+l>=400&&w/(w+l)>=0.55) return true;
+  if (!canReachLimit(w, l, 400, 220)) return false;
+  return SPRTold(w,l);
 }
 
 var QUEUE_BUFFER = 20;

--- a/server.js
+++ b/server.js
@@ -253,7 +253,7 @@ function SPRTold(W,L)
 }
 
 function stDev(n) {
-  return Math.sqrt(Math.pow(n/2,2)/n);
+  return Math.sqrt(n/4);
 }
 
 function canReachLimit(w, l, max, aim) {
@@ -266,7 +266,8 @@ function canReachLimit(w, l, max, aim) {
 }
 
 function SPRT(w, l) {
-  var max = 400, aim = 220;
+  var max = 400;
+  var aim = max / 2 + 2 * stDev(max);
   if(w+l>=max&&w/(w+l)>=(aim/max)) return true;
   if (!canReachLimit(w, l, max, aim)) return false;
   return SPRTold(w,l);

--- a/server.js
+++ b/server.js
@@ -266,8 +266,9 @@ function canReachLimit(w, l, max, aim) {
 }
 
 function SPRT(w, l) {
-  if(w+l>=400&&w/(w+l)>=0.55) return true;
-  if (!canReachLimit(w, l, 400, 220)) return false;
+  var max = 400, aim = 220;
+  if(w+l>=max&&w/(w+l)>=(aim/max)) return true;
+  if (!canReachLimit(w, l, max, aim)) return false;
   return SPRTold(w,l);
 }
 


### PR DESCRIPTION
This adds a (hardcoded 400@55%) limit to SPRT. If enough wins (220) cannot be reached at the limit (400) nr of game within 2 stdev, Fail is given.