### PR TITLE
Allow non promoting matches

### DIFF
--- a/server.js
+++ b/server.js
@@ -491,16 +491,17 @@ app.post('/request-match', (req, res) => {
         options.visits = Number(req.body.visits);
     }
 
-    // Sanitize input
-    //   Convert 0, "", "false" , null, NaN and undefined to boolean false
-    //   Otherwise, true
+    // Usage:
+    //   - schedule a Test match, set is_test=true
+    //   curl -F is_test=true <other params>
     //
-    //   curl -F is_test=true
+    //   - schedule a Normal match, leave out the flag
+    //   curl  <other params>
     //
-    if(req.body.is_test === "false")
-        req.body.is_test = false;
+    if (req.body.is_test === 'true')
+        req.body.is_test = true;
     else
-        req.body.is_test = !!req.body.is_test;
+        req.body.is_test = false;
 
     var match = { "network1": req.body.network1,
         "network2": req.body.network2, "network1_losses": 0,

--- a/server.js
+++ b/server.js
@@ -482,10 +482,20 @@ app.post('/request-match', (req, res) => {
         options.visits = Number(req.body.visits);
     }
 
+    // Sanitize input
+    //   Convert 0, "", "false" , null, NaN and undefined to boolean false
+    //   Otherwise, true
+    //
+    if(req.body.is_test === "false")
+        req.body.is_test = false;
+    else
+        req.body.is_test = !!req.body.is_test;
+
     var match = { "network1": req.body.network1,
         "network2": req.body.network2, "network1_losses": 0,
         "network1_wins": 0,
         "game_count": 0, "number_to_play": Number(req.body.number_to_play),
+        "is_test" : req.body.is_test,
         "options": options, "options_hash": get_options_hash(options) };
 
     db.collection("matches").insertOne( match )

--- a/server.js
+++ b/server.js
@@ -49,6 +49,11 @@ var MATCH_EXPIRE_TIME = 30 * 60 * 1000; // matches expire after 30 minutes. Afte
 
 const SI_PREFIXES = ["", "k", "M", "G", "T", "P", "E"];
 
+function network_exists(hash) {
+    var network_file = __dirname + "/network/" + hash + ".gz";
+    return !fs.existsSync(network_file);
+}
+
 // From https://stackoverflow.com/questions/9461621/how-to-format-a-number-as-2-5k-if-a-thousand-or-more-otherwise-900-in-javascrip
 //
 function abbreviateNumber(number, length) {
@@ -440,9 +445,13 @@ app.post('/request-match', (req, res) => {
 
     if (!req.body.network1)
         return res.status(400).send('No network1 hash specified.');
+    else if (network_exists(req.body.network1))
+        return res.status(400).send('network1 hash not found.');
 
     if (!req.body.network2)
         req.body.network2 = null;
+    else if (network_exists(req.body.network2))
+        return res.status(400).send('network2 hash not found.');
 
     // TODO Need to support new --visits flag as an alternative to --playouts. Use visits if both are missing? Don't allow both to be set.
     //


### PR DESCRIPTION
Fix #7 
- Add `is_test` flag to `/request-match` (`-F is_test=true`)
- `/request-match` will reply with type of match queued (`Test` or `Regular`)
- Add `is_test` check before promotion 
- Add tooltip to `vs` link
![test-match](https://user-images.githubusercontent.com/35659961/38158341-224f1fa4-34de-11e8-9cf4-6a1305747cdb.png)

Fix #9 
- Add network exisitence checking for request match
