### PR TITLE
`/submit-network` memory optimization (part 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "async": "^2.5.0",
     "async-lock": "^1.1.2",
     "body-parser": "^1.18.2",
+    "busboy": "^0.2.14",
     "cacheman": "^2.2.1",
     "debug": "^3.1.0",
     "express": "^4.16.2",

--- a/server.js
+++ b/server.js
@@ -547,7 +547,7 @@ app.post('/request-match', (req, res) => {
 // So we don't think the network is newer than it really is. Actually, upsert shouldn't change
 // the ObjectID so date will remain original insertion date.
 //
-app.post('/submit-network', (req, res, next) => {
+app.post('/submit-network', asyncMiddleware((req, res, next) => {
     log_memory_stats("submit network start");
     var busboy = new Busboy({ headers: req.headers });
 
@@ -672,7 +672,7 @@ app.post('/submit-network', (req, res, next) => {
             }
         );
     });
-});
+}));
 
 app.post('/submit-match',  asyncMiddleware( async (req, res, next) => {
     if (!req.files) {


### PR DESCRIPTION
Getting prepared for future network upgrades (256x20 or above)

Submit network should now use minimal memory

Result of uploading 256x20 Network (Gzipped 88.9MB, Unzipped 260MB)
```
submit network start
        rss        36.54 MB
        heapTotal  15.83 MB
        heapUsed   12.25 MB
        external   17.15 MB
Network weights (256 x 20) 00335835cc85548b1b22d79e7df420ab38b9e2b7117a0e18ae9c5cb7a81559fb (175000) uploaded!
submit network ends
        rss        43.04 MB
        heapTotal  16.83 MB
        heapUsed   13.05 MB
        external   21.30 MB
```