### PR TITLE
Add a verification code to tasks and verify if a submitted match has the expected code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 auth_key
+task_secret
 network
 static/rss.xml
 static/networks/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Your project folder should look like this
   - static/
   - views/
   - auth_key                   (dummy file)
+  - task_secret                (dummy file)
   - ...                        (and other project files)
   - server.js
   

--- a/server.js
+++ b/server.js
@@ -23,6 +23,9 @@ const path = require("path");
  * Utilities
  */
 const {
+    set_task_verification_secret,
+    add_match_verification,
+    check_match_verification,
     network_exists,
     checksum,
     seed_from_mongolong,
@@ -36,7 +39,7 @@ const {
 } = require('./classes/utilities.js');
 
 var auth_key = String(fs.readFileSync(__dirname + "/auth_key")).trim();
-var task_secret = String(fs.readFileSync(__dirname + "/task_secret")).trim();
+set_task_verification_secret(String(fs.readFileSync(__dirname + "/task_secret")).trim());
 
 var cacheIP24hr = new Cacheman('IP24hr');
 var cacheIP1hr = new Cacheman('IP1hr');
@@ -70,54 +73,6 @@ var pending_matches = [];
 var MATCH_EXPIRE_TIME = 30 * 60 * 1000; // matches expire after 30 minutes. After that the match will be lost and an extra request will be made.
 
 
-
-/**
- * Compute a verification code from a secret and seed
- *
- * @param seed {string} Some value to compute a verification
- * @returns {string} The verification code
- */
-function compute_task_verification (seed) {
-    return checksum(task_secret + seed, 'sha256');
-}
-
-/**
- * Modify a match task to include secret-derived verification
- *
- * @param task {object} The task to modify with some required properties:
- *          black_hash {string} Network for white included in verification
- *          random_seed {string} Seed for the task reused for verification
- *          white_hash {string} Network for black included in verification
- *          options_hash {string} Existing hash to append verification
- */
-function add_match_verification (task) {
-    // Append the verification to options_hash as the client responds with it
-    task.options_hash += compute_task_verification(task.random_seed + task.white_hash + task.black_hash);
-}
-
-/**
- * Check and clean up the verification from submitted match data
- *
- * @param data {object} The submission form data with required properties:
- *          loserhash {string} Network for loser to recompute the verification
- *          random_seed {string} Seed to recompute the verification
- *          winnerhash {string} Network for winner to recompute the verification
- *          options_hash {string} Hash to extract verification
- *          verification {string} Will be updated with the verification
- * @returns {bool} True if the verification code is consistent with the data
- */
-function check_match_verification (data) {
-    // Allow for 2 expected verification codes for swapped networks
-    const expected = compute_task_verification(data.random_seed + data.winnerhash + data.loserhash);
-    const expected2 = compute_task_verification(data.random_seed + data.loserhash + data.winnerhash);
-    const provided = data.options_hash.slice(-expected.length);
-
-    // Clean up the overloaded options_hash by removing the verification
-    data.options_hash = data.options_hash.slice(0, -expected.length);
-    data.verification = provided;
-
-    return provided === expected || provided === expected2;
-}
 
 function get_options_hash (options) {
     if (options.visits) {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,4 +1,12 @@
-const { network_exists, asyncMiddleware, SPRT } = require('../classes/utilities.js');
+const {
+    set_task_verification_secret,
+    compute_task_verification,
+    add_match_verification,
+    check_match_verification,
+    network_exists,
+    asyncMiddleware,
+    SPRT
+} = require('../classes/utilities.js');
 var assert = require('assert');
 const crypto = require('crypto');
 
@@ -48,5 +56,130 @@ describe('Utilities', function () {
                 assert.notEqual(SPRT(w, l), true);
             }
         })
+    });
+});
+
+describe('Task Verification', () => {
+    const EMPTY_CODE = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    const ABCD_CODE = '88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589';
+    const CDAB_CODE = 'b7caca69b8597456e5db1676b6e6f930527f14c452bf4454a1398c40dc04ee78';
+
+    afterEach(() => set_task_verification_secret(''));
+
+    describe('#set_task_verification_secret(secret)', () => {
+        it('should use a default secret', () => {
+            const code = compute_task_verification('');
+
+            assert.equal(code, EMPTY_CODE);
+        });
+
+        it('should have a default empty string secret', () => {
+            set_task_verification_secret('');
+            const code = compute_task_verification('');
+
+            assert.equal(code, EMPTY_CODE);
+        });
+
+        it('should change secrets', () => {
+            set_task_verification_secret('abcd');
+            const code = compute_task_verification('');
+
+            assert.equal(code, ABCD_CODE);
+        });
+
+        it('should use the latest secret', () => {
+            set_task_verification_secret('abcd');
+            set_task_verification_secret('cdab');
+            const code = compute_task_verification('');
+
+            assert.equal(code, CDAB_CODE);
+        });
+    });
+
+    describe('#compute_task_verification(seed)', () => {
+        it('should compute a code with empty', () => {
+            const code = compute_task_verification('');
+
+            assert.equal(code, EMPTY_CODE);
+        });
+
+        it('should compute a code with strings', () => {
+            const code = compute_task_verification('abcd');
+
+            assert.equal(code, ABCD_CODE);
+        });
+
+        it('should compute a code with numbers', () => {
+            const code = compute_task_verification(1234);
+
+            assert.equal(code, '03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4');
+        });
+    });
+
+    describe('#add_match_verification(task)', () => {
+        it('should append code to options_hash', () => {
+            const options_hash = 'abcd';
+            const task = {
+                black_hash: '',
+                options_hash,
+                random_seed: '',
+                white_hash: ''
+            };
+
+            add_match_verification(task);
+
+            assert.equal(task.options_hash, options_hash + EMPTY_CODE);
+        });
+    });
+
+    describe('#check_match_verification(data)', () => {
+        var data;
+        beforeEach(() => {
+            data = {
+                loserhash: '',
+                options_hash: EMPTY_CODE,
+                random_seed: '',
+                winnerhash: ''
+            };
+        });
+
+        it('should return true if code is valid', () => {
+            assert(check_match_verification(data));
+        });
+
+        it('should clean up options_hash', () => {
+            check_match_verification(data);
+
+            assert.equal(data.options_hash, '');
+        });
+
+        it('should move the verification to its own property', () => {
+            check_match_verification(data);
+
+            assert.equal(data.verification, EMPTY_CODE);
+        });
+
+        describe('allow network hash in either order', () => {
+            const white_hash = 'ab';
+            const black_hash = 'cd';
+
+            beforeEach(() => {
+                data.options_hash = ABCD_CODE;
+            });
+
+            it('should allow winner / loser', () => {
+                data.winnerhash = black_hash;
+                data.loserhash = white_hash;
+
+                assert(check_match_verification(data));
+            });
+
+            it('should allow loser / winner', () => {
+                data.loserhash = black_hash;
+                data.winnerhash = white_hash;
+
+                assert(check_match_verification(data));
+            });
+        });
     });
 });


### PR DESCRIPTION
r? @gcp / @roy7 This requires a new `task_secret` file to be created at the project root, and it can be whatever string. It's used in computing a sha256 hash with the `random_seed` of a task. This hash is used as a verification code appended to `options_hash` of the task sent to clients, and clients currently don't do anything with that value other than send it back to the server.

For match submissions, we extract the verification code from `options_hash` and compute the expected verification code to either accept or reject the submitted match.

This would be instead of #65 with the primary advantage of not needing to store additional state on the server for every match task. Also a benefit is not preventing submissions from laptops or devices that are more likely to change IP addresses. The verification is also done synchronously without needing a db query.

Some potential followups:
- check verification for selfplay games
- ~only allow a verification code to be used once (which right now would imply no same random_seed, but this could be scoped to a given matchup by including the network hash in computing the verification code~ partially implemented in the 2nd commit
- preventing reuse of a code for a given matchup
- time limited code (include a timestamp in `options_hash` and when it returns, verify that it's within some allowed time ago