### PR TITLE
Zoom elo graph

### DIFF
--- a/static/elo.html
+++ b/static/elo.html
@@ -28,6 +28,12 @@
           "transform": [
             { "filter": { "field": "best", "equal": "true" } }
           ],
+          "selection": {
+            "grid": {
+              "type": "interval",
+              "bind": "scales"
+            }
+          },
           "mark": {
             "type": "line",
             "interpolate": "monotone"


### PR DESCRIPTION
Added zooming for elo graph
- mouse drag to move around the graph
- mouse wheel scroll to zoom in & out

![zoom](https://user-images.githubusercontent.com/35659961/39286041-0da81746-495f-11e8-9e3e-3ca644ed060b.gif)
