### PR TITLE
Use ELF network in half of self-play games

### DIFF
--- a/server.js
+++ b/server.js
@@ -1300,6 +1300,10 @@ app.get('/get-task/:version(\\d+)', asyncMiddleware( async (req, res, next) => {
 
         task.hash = best_network_hash;
 
+        // For now, have autogtp 16 or newer play half of self-play with
+        // Facebook's ELF Open Go network, which uses network version 2.
+        if (req.params.version >= 16 && Math.random() < .5) task.hash = "62b5417b64c46976795d10a6741801f15f857e5029681a42d02c9852097df4b9";
+
         res.send(JSON.stringify(task));
 
         console.log(req.ip + " (" + req.headers['x-real-ip'] + ") " + " got task: selfplay");


### PR DESCRIPTION
As @gcp suggested in https://github.com/gcp/leela-zero/issues/1311#issuecomment-386422486:
> We can just have the server ask the clients to self-play with it, rather than with the best-network. Exclusively using it probably isn't good, but something like a 50/50 mix with best-network could work. The training of our networks then becomes analyzing mistakes in own games, and also observing how a superior player plays.

This assumes AUTOGTP_VERSION is bumped higher than 15 to support networks with version 2:
https://github.com/gcp/leela-zero/blob/97c2f8137a3ea24938116bfbb2b0ff05c83903f0/autogtp/Management.h#L33