### PR TITLE
Avoid cached elo.html with a different url and script to load content

### DIFF
--- a/server.js
+++ b/server.js
@@ -1188,7 +1188,7 @@ app.get('/',  asyncMiddleware( async (req, res, next) => {
         page += "<a href=\"https://docs.google.com/spreadsheets/d/e/2PACX-1vTsHu7T9vbfLsYOIANnUX9rHAYu7lQ4AlpVIvCfn60G7BxNZ0JH4ulfbADEedPVgwHxaH5MczdH853l/pubchart?oid=286613333&format=interactive\">Original strength graph</a>. (Mostly obsolete.)<br>";
         page += "<br>";
         page += `<h4>Recent Strength Graph (<a href="/static/elo.html">Full view</a>.)</h4>`;
-        page += "<iframe width=\"950\" height=\"655\" seamless frameborder=\"0\" scrolling=\"no\" src=\"/static/elo.html#recent=2500000\"></iframe>";
+        page += `<iframe width="950" height="655" seamless frameborder="0" scrolling="no" src="/static/elo.html?0#recent=2500000"></iframe><script>(i => i.contentWindow.location = i.src)(document.querySelector("iframe"))</script>`;
         page += "<br><br>Times are in GMT+0100 (CET)<br>\n";
         page += network_table;
         page += match_table;


### PR DESCRIPTION
Fix #78. r?@roy7 Grabbed a workaround from https://bugzilla.mozilla.org/show_bug.cgi?id=356558#c7