### PR TITLE
Fix `weight_parser` to parse weight file ended with newline

### DIFF
--- a/classes/weight_parser.js
+++ b/classes/weight_parser.js
@@ -4,6 +4,7 @@ class weight_parser extends Writable {
     constructor(options) {
         super(options);
         this.newline = this.space = 0;
+        this.lastNewline = null;
     }
 
     write(chunk, encoding, next) {
@@ -19,10 +20,12 @@ class weight_parser extends Writable {
             else if (this.newline == 2 && c == 0x20)  // 0x20 = ' ' = space
                 this.space++;
         }
+        // track whether the weight file ended with newline
+        this.lastNewline = chunk[chunk.length - 1] == 0x0A;
     }
 
     read() {
-        var filters = this.space + 1, blocks = (this.newline + 1 - (1 + 4 + 14)) / 8;
+        var filters = this.space + 1, blocks = (this.newline + (this.lastNewline ? 0 : 1) - (1 + 4 + 14)) / 8;
 
         if(!Number.isInteger(blocks))
             blocks = 0;

--- a/scripts/scan_networks.js
+++ b/scripts/scan_networks.js
@@ -1,6 +1,8 @@
 const MongoClient = require('mongodb').MongoClient;
-const fs = require("fs");
+const fs = require("fs-extra");
 const zlib = require("zlib");
+const path = require('path');
+var weight_parser = require('../classes/weight_parser.js');
 
 
 (async () => {
@@ -20,50 +22,38 @@ const zlib = require("zlib");
 
         console.log(`Found ${networks.length} networks need re-scanning.`)
 
-        var network_folder = __dirname + "/../network/";
+        var network_folder = path.join(__dirname, "..", "network");
 
         // Start Re-Scanning
         for (var network of networks) {
-            var network_path = network_folder + network.hash + ".gz";
+            var network_path = path.join(network_folder, `${network.hash}.gz`);
 
             if (!fs.existsSync(network_path)) {
                 console.log(`Network ${network.hash} not found`);
                 return;
             }
 
-            var fileBuffer = fs.readFileSync(network_path);
-            var content = zlib.unzipSync(fileBuffer).toString();
+            var parser = new weight_parser;
 
-            var space = 0, newline = 0;
-            for (let x = 0; x < content.length; ++x) {
-                var c = content[x];
-
-                if (c == "\n")
-                    newline++;
-                else if (newline == 2 && c == " ")
-                    space++;
-            }
-            var filters = space + 1, blocks = (newline + 1 - (1 + 4 + 14)) / 8;
+            var architecture = await new Promise((resolve) => {
+                fs.createReadStream(network_path)
+                    .pipe(zlib.createGunzip())
+                    .pipe(parser)
+                    .on('finish', () => resolve(parser.read()))
+            });
 
             await db.collection("networks").updateOne(
-                {
-                    _id: network._id
-                },
-                {
-                    $set: {
-                        filters: filters, blocks: blocks
-                    }
-                }
+                { _id: network._id },
+                { $set: architecture }
             );
 
-            console.log(`Network ${network.hash} is ${filters}x${blocks} and updated in database`);
-
+            console.log(`Network ${network.hash} is ${architecture.filters}x${architecture.blocks} and updated in database`);
         }
-
+    } catch (err) {
+        console.error(err);
+    } finally {
+        // always close db connection
         db.close();
         console.log("Done");
-
-    } catch (err) {
-        console.log(err);
     }
 })();


### PR DESCRIPTION
LZ network files came out of training pipeline did **not** have newline at the end of file, and the parser was written to work with it.

The ELF network file was converted manually and ended with newline, this has caused the parser failed to parse.

This fix will be able to parse both weight files (with or without newline at the end of file).

@roy7  to fix the ELF network, please run `node scripts/scan_networks.js`


