### PR TITLE
Fix scripts where when error occurred it should continue to next network.

### DIFF
--- a/scripts/scan_networks.js
+++ b/scripts/scan_networks.js
@@ -30,7 +30,7 @@ var weight_parser = require('../classes/weight_parser.js');
 
             if (!fs.existsSync(network_path)) {
                 console.log(`Network ${network.hash} not found`);
-                return;
+                continue;
             }
 
             var parser = new weight_parser;


### PR DESCRIPTION
@roy7 Please re-run the script.
In previous run, the script was exited when error occurred, now it should continue.