### PR TITLE
Show elf self play games (part 2)

### DIFF
--- a/mongodb.indexes
+++ b/mongodb.indexes
@@ -5,6 +5,7 @@ db.games.createIndex({"ip":-1,"_id":-1}, {"name":"ip_-1__id_-1","background":tru
 db.games.createIndex({"ip":1}, {"name":"ip_1"});
 db.games.createIndex({"networkhash":1}, {"name":"networkhash_1"});
 db.games.createIndex({"sgfhash":1}, {"unique":true,"name":"sgfhash_1"});
+db.games.createIndex({"_id":1, "networkhash":1}, {"name":"_id_1_networkhash_1","background":true});
 
 // match-games
 db.match-games.createIndex({"_id":1}, {"name":"_id_"});

--- a/server.js
+++ b/server.js
@@ -62,7 +62,7 @@ process.on('uncaughtException', (err) => {
 
 // https://blog.tompawlak.org/measure-execution-time-nodejs-javascript
 
-var counter, elf_counter;
+var counter, elf_counter = 0;
 var best_network_mtimeMs = 0;
 var best_network_hash_promise = null;
 var db;
@@ -967,16 +967,15 @@ app.get('/',  asyncMiddleware( async (req, res, next) => {
         .then((list) => {
             return (list.length + " in past hour.<br>");
         }),
-        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60 * 24) } }).count()
+        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60 * 24) }, networkhash : { $ne : ELF_NETWORK } }).count()
         .then((count) => {
             return (counter + " total selfplay games, (" + count + " in past 24 hours, ");
         }),
-        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60) } }).count()
+        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60) }, networkhash: { $ne: ELF_NETWORK } }).count()
         .then((count) => {
             return (count + " in past hour).<br/>");
         }),
-/*
-        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60 * 24) }, networkhash: ELF_NETWORK }).count()
+        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60 * 24) }, networkhash : ELF_NETWORK }).count()
         .then((count) => {
             return (elf_counter + " total ELF selfplay games, (" + count + " in past 24 hours, ");
         }),
@@ -984,7 +983,6 @@ app.get('/',  asyncMiddleware( async (req, res, next) => {
         .then((count) => {
             return (count + " in past hour).<br/>");
         }),
-*/
         db.collection("match_games").find().count()
         .then((count) => {
             return (count + " total match games. (");


### PR DESCRIPTION
@roy7 
I decided to go with the index solution

I've mocked up 1 million games locally and tested the query with new index, it looks fine to me.

## To test new index on production server before merging
Create new index in the background (non-blocking operation)
```
db.games.createIndex({"_id":1, "networkhash":1}, {"name":"_id_1_networkhash_1","background":true})
```

Please try the command (query # of LZ games in past 24 hours) below in mongo console and see the performance 
```
db.games.explain('executionStats').find({
  _id: { $gt : ObjectId(Math.floor((Date.now()-1000*60*60*24)/1000).toString(16) + '0000000000000000') }, 
  networkhash: { $ne : '62b5417b64c46976795d10a6741801f15f857e5029681a42d02c9852097df4b9' }
}).count()
```
I would expect the result containing the following:
- `"indexName" : "_id_1_networkhash_1"`, the query is utilising new index
- `"executionTimeMillis" : 86` or similar number < 1000
- `"totalDocsExamined" : 0`, no docs need to be examined, index scan should do the work 

