### PR TITLE
Display total # of ELF self play games.

### DIFF
--- a/server.js
+++ b/server.js
@@ -973,18 +973,8 @@ app.get('/',  asyncMiddleware( async (req, res, next) => {
         }),
         db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60) } }).count()
         .then((count) => {
-            return (count + " in past hour).<br/>");
+            return (count + " in past hour).<br/>" + elf_counter + " total ELF selfplay games.<br/>");
         }),
-/*
-        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60 * 24) }, networkhash: ELF_NETWORK }).count()
-        .then((count) => {
-            return (elf_counter + " total ELF selfplay games, (" + count + " in past 24 hours, ");
-        }),
-        db.collection("games").find({ _id: { $gt: objectIdFromDate(Date.now() - 1000 * 60 * 60) }, networkhash: ELF_NETWORK }).count()
-        .then((count) => {
-            return (count + " in past hour).<br/>");
-        }),
-*/
         db.collection("match_games").find().count()
         .then((count) => {
             return (count + " total match games. (");


### PR DESCRIPTION
Continue from #98 

@roy7 has confirmed (https://github.com/gcp/leela-zero-server/pull/97#issuecomment-386843053) the total count was an instant query, we'll now only display total # self play games for ELF

> when I do it in console the result is instant.
>> { "_id" : { "type" : "ELF" }, "total" : 2231 }
>> { "_id" : { "type" : "LZ" }, "total" : 7259277 }

Sample output from my local machine.
```
300 total selfplay games, (77616 in past 24 hours, 0 in past hour).
9 total ELF selfplay games.
```
