### PR TITLE
Vue: Replace jQuery with Vue

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -37,4 +37,5 @@ html(lang="en")
         script(src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous")
         script(src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous")
         script(src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous")
+        script(src="https://cdn.jsdelivr.net/npm/vue@2.5.16/dist/vue.min.js" crossorigin="anonymous")
         block script

--- a/views/networks/index.pug
+++ b/views/networks/index.pug
@@ -8,18 +8,19 @@ block meta
 block script
     script(src="/static/timeago.js")
     script.
-        jQuery(".time-ago").each((_, elm) => {
-            var epoch = +elm.innerText, delta = Date.now() - epoch;
+        Vue.filter('timeAgo', function(value) {
+            var epoch = +value, delta = Date.now() - epoch;
 
             if(delta > 60 * 60 * 24 * 1000) {
                 let date = new Date(epoch);
-                elm.innerText = date.toLocaleDateString() + " " + date.toLocaleTimeString();
+                return date.toLocaleDateString() + " " + date.toLocaleTimeString();
             } else {
-                elm.innerText = deltaToAgo(delta);
+                return deltaToAgo(delta);
             }
         })
-        jQuery(".user-time-zone").text(Intl.DateTimeFormat().resolvedOptions().timeZone)
-        jQuery('[data-toggle="tooltip"]').tooltip()
+        var app = new Vue({
+            el: 'main',
+        })
 
 block content
     .row.mt-4
@@ -49,7 +50,7 @@ block content
                         tr
                             td #{networks.length - n - 1}
                             td 
-                                span.time-ago #{network._id.getTimestamp().getTime()}
+                                span.time-ago {{ '#{network._id.getTimestamp().getTime()}' | timeAgo }}
                             td #{network.hash.slice(0, 6)}
                             td #{network.filters}x#{network.blocks}
                             td #{network.game_count}

--- a/views/networks/profile.pug
+++ b/views/networks/profile.pug
@@ -79,7 +79,7 @@ block content
                             tbody
                             - for(let match of matches) 
                                 tr
-                                    td.time-ago {{ '#{match._id.getTimestamp().getTime()} | timeAgo }}
+                                    td.time-ago {{ '#{match._id.getTimestamp().getTime()}' | timeAgo }}
                                     td 
                                         - var title1 = `${match.network1.training_count.abbr(4)}${match.network1.training_steps ? '+' + match.network1.training_steps.abbr(3):''}`
                                         - var title2 = `${match.network2.training_count.abbr(4)}${match.network2.training_steps ? '+' + match.network2.training_steps.abbr(3):''}`

--- a/views/networks/profile.pug
+++ b/views/networks/profile.pug
@@ -23,6 +23,9 @@ block script
         })
         var app = new Vue({
             el: 'main',
+            data: {
+                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            }
         })
 
 block content
@@ -63,7 +66,7 @@ block content
                 .table-responsive
                     table.table.table-bordered.table-hover
                         caption.
-                             (*) Times are displayed in #[span.user-time-zone] time zone
+                             (*) Times are displayed in {{ timezone }} time zone
                         
                         //- Start Match Table
                         - if(matches)

--- a/views/networks/profile.pug
+++ b/views/networks/profile.pug
@@ -11,18 +11,19 @@ block meta
 block script
     script(src="/static/timeago.js")
     script.
-        jQuery(".time-ago").each((_, elm) => {
-            var epoch = +elm.innerText, delta = Date.now() - epoch;
+        Vue.filter('timeAgo', function(value) {
+            var epoch = +value, delta = Date.now() - epoch;
 
             if(delta > 60 * 60 * 24 * 1000) {
                 let date = new Date(epoch);
-                elm.innerText = date.toLocaleDateString() + " " + date.toLocaleTimeString();
+                return date.toLocaleDateString() + " " + date.toLocaleTimeString();
             } else {
-                elm.innerText = deltaToAgo(delta);
+                return deltaToAgo(delta);
             }
         })
-        jQuery(".user-time-zone").text(Intl.DateTimeFormat().resolvedOptions().timeZone)
-        jQuery('[data-toggle="tooltip"]').tooltip()
+        var app = new Vue({
+            el: 'main',
+        })
 
 block content
     .row.mt-4
@@ -75,7 +76,7 @@ block content
                             tbody
                             - for(let match of matches) 
                                 tr
-                                    td.time-ago #{match._id.getTimestamp().getTime()}
+                                    td.time-ago {{ '#{match._id.getTimestamp().getTime()} | timeAgo }}
                                     td 
                                         - var title1 = `${match.network1.training_count.abbr(4)}${match.network1.training_steps ? '+' + match.network1.training_steps.abbr(3):''}`
                                         - var title2 = `${match.network2.training_count.abbr(4)}${match.network2.training_steps ? '+' + match.network2.training_steps.abbr(3):''}`


### PR DESCRIPTION
jQuery is replaced by vue filter (https://vuejs.org/v2/guide/filters.html), which improves readability

I searched around found no other place jQuery is used, I assume I can remove it now? I'd like to confirm with @rchs819 first.