### PR TITLE
fix `how_many_games_to_queue` for SPRT pass match

### DIFF
--- a/classes/utilities.js
+++ b/classes/utilities.js
@@ -180,11 +180,11 @@ function SPRT(w, l) {
 
 var QUEUE_BUFFER = 25;
 
-function how_many_games_to_queue(max_games, w_obs, l_obs, pessimistic_rate) {
+function how_many_games_to_queue(max_games, w_obs, l_obs, pessimistic_rate, isBest) {
     var games_left = max_games - w_obs - l_obs;
 
-    if (SPRT(w_obs, l_obs) === true) {
-        return games_left + QUEUE_BUFFER;
+    if (isBest || SPRT(w_obs, l_obs) === true) {
+        return games_left;
     }
 
     if (SPRT(w_obs, l_obs) === false) {

--- a/server.js
+++ b/server.js
@@ -1273,7 +1273,8 @@ function shouldScheduleMatch (req, now) {
                 match.number_to_play,
                 match.network1_wins,
                 match.network1_losses,
-                PESSIMISTIC_RATE);
+                PESSIMISTIC_RATE,
+                bestRatings.has(match.network1));
   var result = needed > requested;
   console.log(`Need ${needed} match games. Requested ${requested}, deleted ${deleted}. Oldest ${oldest}m ago. Will schedule ${result ? "match" : "selfplay"}.`);
 


### PR DESCRIPTION
For a SPRT Pass match, we should only allocate what we need. (i.e. remove `QUEUE_BUFFER`)
It might take longer to reach 400 games, but I think time is less important here, and more resources can be allocated to self play games.