### PR TITLE
Share game processing logic for hiding ip and calculating duration and win rates

### DIFF
--- a/views/match-games.pug
+++ b/views/match-games.pug
@@ -8,24 +8,37 @@ html(lang="en")
         table(id="sort" border="1")
             thead
                 tr
-                    th Client
+                    th Game
+                    th Win Rate
                     th Match Hash
                     th Winner
                     th Score
                     th Move Count
+                    th Duration
                     th Download
+                    th Client
+                    th Version
             tbody
                 each item in data
                     tr
-                        td #{item.ip}
+                        td #{item.num}
+                        td #{item.winrate}%
                         td
-                            a(href="/viewmatch/" + item.sgfhash + "?viewer=wgo")  #{item.sgfhash}
+                            a(href="/viewmatch/" + item.sgfhash + "?viewer=wgo")  #{item.sgfhash.slice(0, 32)}
                         td #{item.winnerhash.slice(0, 8)}
                         td #{item.score}
                         td #{item.movescount}
+                        td #{item.duration} minutes
                         td
                             a(href="/viewmatch/" + item.sgfhash + ".sgf")  sgf
+                        td #{item.ip}
+                        td #{item.clientversion}
         script.
+            Tablesort.extend('minutes', item => /minutes/.test(item), (a, b) => {
+                a = (a.match(/([.\d]+) minutes/) || [])[1] || 0;
+                b = (b.match(/([.\d]+) minutes/) || [])[1] || 0;
+                return b - a;
+            });
             Tablesort.extend('score', function(item) {
                 return item.match(/(?:b|w)+([\d.]+|resign)/i);
             }, function(a, b) {

--- a/views/self-plays.pug
+++ b/views/self-plays.pug
@@ -8,31 +8,31 @@ html(lang="en")
         table(id="sort" border="1")
             thead
                 tr
-                    th Client
-                    th Version
                     th Self-Play Hash
                     th Network
-                    th Move Count
                     th Winner
+                    th Move Count
                     th Started
                     th Duration
                     th Download
+                    th Client
+                    th Version
             tbody
                 each item in data
                     tr
-                        td #{item.ip}
-                        td #{item.clientversion}
                         td
-                            a(href="/view/" + item.sgfhash + "?viewer=wgo")  #{item.sgfhash}
+                            a(href="/view/" + item.sgfhash + "?viewer=wgo")  #{item.sgfhash.slice(0, 32)}
                         td #{item.networkhash.slice(0, 8)}
-                        td #{item.movescount}
                         td #{item.winnercolor}
-                        td #{item.started}
-                        td #{item.duration}
+                        td #{item.movescount}
+                        td #{item.started} minutes ago
+                        td #{item.duration} minutes
                         td
                             a(href="/view/" + item.sgfhash + ".sgf")  sgf
+                        td #{item.ip}
+                        td #{item.clientversion}
         script.
-            Tablesort.extend('minutes', item => /(^\?\?\?$|minutes)/.test(item), (a, b) => {
+            Tablesort.extend('minutes', item => /minutes/.test(item), (a, b) => {
                 a = (a.match(/([.\d]+) minutes/) || [])[1] || 0;
                 b = (b.match(/([.\d]+) minutes/) || [])[1] || 0;
                 return b - a;


### PR DESCRIPTION
r?@roy7 Win rates are shown for matches. Start time shown for self-play. Reorganized the table a little bit to be narrower (shorter hash) and added duration to both.

![screen shot 2018-05-22 at 7 13 46 am](https://user-images.githubusercontent.com/438537/40368118-e709950c-5d8f-11e8-900a-c6bc760bb063.png)
