### PR TITLE
Detect fast clients based on self-play durations

### DIFF
--- a/classes/utilities.js
+++ b/classes/utilities.js
@@ -138,7 +138,7 @@ function process_games_list(list, ip, winner = "") {
         const displayMinutes = (key, reference) => {
             const minutes = (reference / 1000 - startTime) / 60;
             item[key] = minutes >= 0 && minutes <= 24 * 60 ? minutes.toFixed(1) : "???";
-        }
+        };
         displayMinutes("started", Date.now());
         displayMinutes("duration", item._id.getTimestamp());
     });


### PR DESCRIPTION
r?@roy7 This will print out a message like:

From recent 1234 games, found 1 fast clients:  Map { '::1' => 12 }

I picked some magic numbers:
recent = 24 hours of games
fast = faster than 15 minutes duration
threshold = have at least 3 fast games