### PR TITLE
Switch to a moves/minute check for fast clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,16 +92,16 @@ async function get_fast_clients() {
     const start = Date.now();
     try {
         // Get some recent self-play games to calculate durations from seeds
-        const games = await db.collection("games").find({}, { ip: 1, random_seed: 1 })
+        const games = await db.collection("games").find({}, { ip: 1, movescount: 1, random_seed: 1 })
             .sort({ _id: -1 }).limit(1000).toArray();
 
-        // Count the number of games that were completed faster than 15 minutes
+        // Count the number of games that played at least 10 moves per minute
         fastClientsMap.clear();
         games.forEach(game => {
             const seed = (s => s instanceof Long ? s : new Long(s))(game.random_seed);
             const startTime = get_timestamp_from_seed(seed);
-            const duration = game._id.getTimestamp() / 1000 - startTime;
-            if (duration > 0 && duration <= 60 * 15) {
+            const minutes = (game._id.getTimestamp() / 1000 - startTime) / 60;
+            if (minutes > 0 && game.movescount / minutes >= 10) {
                 fastClientsMap.set(game.ip, ~~fastClientsMap.get(game.ip) + 1);
             }
         });


### PR DESCRIPTION
@roy7 Looks like the refactoring to maintain similar get_fast_clients behavior (old: 4 games per hour and new: games within 15 minutes) was successful, so optimizing a bit more to check the move rate instead of plain durations to skip clients that happen to play a bunch of early-92-move-resign games.

From a snapshot of 400 recent self-play games, 129 games were played within 15 minutes, so that's the top 33% of those games. Whereas 106 games were played with at least 10 moves per minute, i.e., top 27%. For reference, a threshold of 11 moves/minute would have found 70 games (top 18%), and 10.5 finds 84 (21%).

Here's node console to test how long and how many clients it finds, so you can adjust the 10 to something else to pick some desired number of fast clients:
```js
let { get_timestamp_from_seed, objectIdFromDate } = require("./classes/utilities");
let { Long, MongoClient } = require("mongodb");
let fastClientsMap = new Map();

async function get_fast_clients() {
    const start = Date.now();
    try {
        // Get some recent self-play games to calculate durations from seeds
        const games = await db.collection("games").find({}, { ip: 1, movescount: 1, random_seed: 1 })
            .sort({ _id: -1 }).limit(1000).toArray();
        
        // Keep track of the move rate of each game by client
        fastClientsMap.clear();
        games.forEach(game => {
            const seed = (s => s instanceof Long ? s : new Long(s))(game.random_seed);
            const startTime = get_timestamp_from_seed(seed);
            const minutes = (game._id.getTimestamp() / 1000 - startTime) / 60;
            
            // Make sure we have some reasonable duration
            if (minutes > 0 && minutes <= 60 * 24)
                fastClientsMap.set(game.ip, [...(fastClientsMap.get(game.ip) || []), game.movescount / minutes]);
        });
        
        // Clean up the map to be a single rate value with enough entries
        for (const [ip, rates] of fastClientsMap) {
            // Remove clients that submitted only a couple fast games (in case
            // some unexpected seed just happens to match the duration)
            if (rates.length < 3)
                fastClientsMap.delete(ip);
            else
                fastClientsMap.set(ip, rates.reduce((t, v) => t + v) / rates.length);
        }
        
        // Short circuit if there's nothing interesting to do
        if (fastClientsMap.size == 0) {
            console.log("No clients found with sufficient rate data");
            return;
        }       
        
        // Print out some statistics on rates
        const sortedRates = [...fastClientsMap.values()].sort((a, b) => a - b);
        const quartile = n => { 
            const index = n / 4 * (sortedRates.length - 1);
            return index % 1 == 0 ? sortedRates[index] : (sortedRates[Math.floor(index)] + sortedRates[Math.ceil(index)]) / 2;
        };
        console.log("Client moves per minute rates:", ["min", "25%", "median", "75%", "max"].map((text, index) => `${quartile(index).toFixed(1)} ${text}`).join(", "));
        
        // Keep only clients that have the top 25% rates
        const top25Rate = quartile(3);
        for (const [ip, rate] of fastClientsMap) {
            if (rate < top25Rate)
                fastClientsMap.delete(ip);
        }
        
        console.log(`In ${Date.now() - start}ms from recent ${games.length} games, found ${fastClientsMap.size} fast clients:`, fastClientsMap);
    } catch (err) {
        console.log("Failed to get recent games for fast clients:", err);
    }   
}

MongoClient.connect("mongodb://localhost/test", (err, database) => {
    db = database;
    get_fast_clients();
});
```

Alternatively, we could specify some maximum number of clients "fastest 30" or percentile "top 20% fastest" with some extra math.