### PR TITLE
Update pessimistic rate to better match the minimum win rate

### DIFF
--- a/server.js
+++ b/server.js
@@ -227,7 +227,7 @@ async function get_best_network_hash() {
     .catch(err => console.error(err));
 }
 
-const PESSIMISTIC_RATE = 0.2;
+const PESSIMISTIC_RATE = 0.4;
 
 app.enable("trust proxy");
 


### PR DESCRIPTION
r?@roy7 The most recent 100 matches with sorted win rates:
```
39.55 40.68 40.77 40.96 41.63 42.48 42.86 43.08 43.86 43.93
44.07 45.07 45.66 45.68 46.42 46.67 46.67 46.79 46.91 47.10
47.69 48.01 48.16 48.52 48.59 48.60 48.60 48.71 48.84 48.95
48.95 49.11 49.17 49.36 49.45 49.49 49.67 49.86 50.16 50.43
50.47 50.60 50.66 50.68 50.92 51.18 51.19 51.24 51.40 51.42
51.45 51.48 51.52 51.61 51.65 51.82 51.82 51.93 52.13 52.16
52.17 52.23 52.29 52.31 52.42 52.45 52.58 52.63 52.72 52.80
52.85 52.87 52.90 52.94 52.98 53.02 53.13 53.33 53.81 53.81
54.34 54.72 54.91 54.96 55.16 55.20 55.43 56.20 56.34 56.48
56.66 57.34 57.50 57.87 58.97 59.63 59.67 89.62 93.27 94.23
```

With no games, it'll try to schedule 138 games initially instead of 54.

I believe the original 0.2 rate was when there was oversampling issues leading to many networks failing with even no wins.