### PR TITLE
add logging to every request using morgan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ task_secret
 network
 static/rss.xml
 static/networks/
+logs/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,6 +353,14 @@
         }
       }
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -1291,7 +1299,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
         "duplexer": "0.1.1",
@@ -3445,6 +3453,28 @@
         "require_optional": "1.0.1"
       }
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3644,6 +3674,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
@@ -4256,6 +4291,11 @@
       "requires": {
         "glob": "7.1.2"
       }
+    },
+    "rotating-file-stream": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-1.3.6.tgz",
+      "integrity": "sha512-JTXaSEXi8mAxhA6m+LF8wBdkUggoGP7uHDD73Igk/CmoVzYak2bE7C/pV1WqO8evl1BBvb7DelF5sJD8huiqHA=="
     },
     "rss": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "maxmind": "^2.3.0",
     "moment": "^2.21.0",
     "mongodb": "^2.2.33",
+    "morgan": "^1.9.0",
     "nodemon": "^1.14.11",
     "pug": "^2.0.0-rc.4",
     "request": "^2.85.0",
     "retricon-without-canvas": "^1.0.0",
+    "rotating-file-stream": "^1.3.6",
     "rss": "^1.2.2",
     "zlib": "^1.0.5"
   },


### PR DESCRIPTION
- rotate log daily and keep max 7 files (1 week) in `/logs/` folder
- log memory usage for every request (before & after)
- log uploaded file size for POST requests

### Examples
submit network, we can see the uploaded size 116864761
```
-->Before rss: 46.15 MB, heapTotal: 22.32 MB, heapUsed: 17.51 MB, external: 17.30 MB
POST /submit-network 400 116864761 581.455 ms
-->After  rss: 52.38 MB, heapTotal: 23.32 MB, heapUsed: 18.04 MB, external: 23.78 MB
```

home page 
```
-->Before rss: 52.38 MB, heapTotal: 23.32 MB, heapUsed: 18.12 MB, external: 23.78 MB
GET / 200 - 86.408 ms
-->After  rss: 48.51 MB, heapTotal: 22.32 MB, heapUsed: 18.07 MB, external: 17.54 MB
```

static assets
```
-->Before rss: 46.54 MB, heapTotal: 22.32 MB, heapUsed: 18.14 MB, external: 17.54 MB
GET /data/elograph.json 304 - 2.491 ms
-->After  rss: 46.63 MB, heapTotal: 22.32 MB, heapUsed: 18.23 MB, external: 17.56 MB
```

network profile
```
-->Before rss: 46.81 MB, heapTotal: 22.32 MB, heapUsed: 18.41 MB, external: 17.56 MB
GET /network-profiles 200 - 443.455 ms
-->After  rss: 62.86 MB, heapTotal: 38.58 MB, heapUsed: 26.00 MB, external: 17.34 MB
```