### PR TITLE
Add LZ to network number, commas to games, and optional steps

### DIFF
--- a/views/networks/index.pug
+++ b/views/networks/index.pug
@@ -33,12 +33,13 @@ block content
                             th Download
                     template(slot="items"  slot-scope="props")
                         tr
-                            td {{ networks.length - props.index - 1 }}
+                            td LZ{{ networks.length - props.index - 1 }}
                             td {{ props.item.time | timeAgo }}
                             td
                                 a(:href="`/network-profiles/${props.item.hash}`") {{ props.item.hash.slice(0, 8) }}
                             td {{ props.item.filters }} x {{ props.item.blocks }}
-                            td {{ props.item.game_count }}
-                            td {{ props.item.training_count | abbr(4) }} +{{ props.item.training_steps | abbr(3)}}
+                            td {{ props.item.game_count.toLocaleString() }}
+                            td {{ props.item.training_count | abbr(4) }}
+                                span(v-if="props.item.training_steps") +{{ props.item.training_steps | abbr(3)}}
                             td
                                 a(:href="`/networks/${props.item.hash}.gz`") Download


### PR DESCRIPTION
r?@roy7 Some clean up of the networks index page.

Before:
<img width="1128" alt="screen shot 2018-06-05 at 11 25 14 am" src="https://user-images.githubusercontent.com/438537/40995244-6c103430-68b3-11e8-9896-546846b9db84.png">

After:
<img width="1123" alt="screen shot 2018-06-05 at 11 22 45 am" src="https://user-images.githubusercontent.com/438537/40995256-716401c8-68b3-11e8-93fa-8a9cc04d158f.png">
