### PR TITLE
Fix ttl of matches cache

### DIFF
--- a/classes/dbutils.js
+++ b/classes/dbutils.js
@@ -5,7 +5,7 @@ const {
     LLR
 } = require("./utilities.js");
 
-const cache_matches = new Cacheman();
+const cache_matches = new Cacheman("matches", { ttl: "1y" });
 
 async function get_matches_from_db(db, { limit = 100, network } = {}) {
     const matches = await db.collection("matches")


### PR DESCRIPTION
Turns out cacheman has a default ttl of 60 seconds, see:
https://github.com/cayasso/cacheman/blob/2.2.1/lib/index.js#L114