### PR TITLE
Fix #176: Update cache when network2 got filled

### DIFF
--- a/classes/dbutils.js
+++ b/classes/dbutils.js
@@ -55,16 +55,8 @@ async function update_matches_stats_cache(db, match_id, is_network1_win) {
     cache_matches.set("matches", matches);
 }
 
-// New match requested: get the latest match and push it into cache
-async function new_matches_cache(db, network) {
-    const matches = await get_matches_from_cache(db);
-    const new_match = await get_matches_from_db(db, { limit: 1, network });
-    if (matches[0]._id.toString() != new_match[0]._id.toString()) {
-        // Update only if cache is out of date
-        console.log("Push new match into cache");
-        matches.unshift(new_match[0]);
-        cache_matches.set("matches", matches);
-    }
+function clear_matches_cache() {
+    cache_matches.clear(() => console.log("Cleared new match cache."));
 }
 
 // Get access log begin with `url`
@@ -89,6 +81,6 @@ module.exports = {
     get_matches_from_db,
     get_matches_from_cache,
     update_matches_stats_cache,
-    new_matches_cache,
+    clear_matches_cache,
     get_access_logs
 };

--- a/server.js
+++ b/server.js
@@ -483,7 +483,7 @@ app.post("/request-match", (req, res) => {
     db.collection("matches").insertOne(match)
     .then(() => {
         // Update cache
-        dbutils.new_matches_cache(db, match.network1);
+        dbutils.clear_matches_cache();
 
         // Client only accepts strings for now
         Object.keys(match.options).map(key => {
@@ -1419,6 +1419,7 @@ app.get("/get-task/:autogtp(\\d+)(?:/:leelaz([.\\d]+)?)", asyncMiddleware(async(
                         res.send("ERROR: /get-task setting network2: " + err);
                         return;
                     }
+                    dbutils.clear_matches_cache();
                     console.log("Match " + match._id + " set network2 to best: " + match.network2);
             });
         }


### PR DESCRIPTION
network2 of new match could be null resulting in it cannot be found by
db query (joining on network2)

also clear cache instead of inserting an item to make things simple
and stupid