### PR TITLE
views/index: Fix release warning URL

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -17,7 +17,7 @@ block script
         })
 
 block content
-    v-alert(:value="true" color="warning") 2018-05-09 <a href=\"https://github.com/gcp/leela-zero/releases\">Leela Zero 0.15 + AutoGTP v16</a>. <b>Update required.</b>
+    v-alert(:value="true" color="warning") 2018-05-09 <a href="https://github.com/gcp/leela-zero/releases">Leela Zero 0.15 + AutoGTP v16</a>. <b>Update required.</b>
     div(class="text-xs-center")
         iframe(width="950" height="655" seamless frameborder="0" scrolling="no" src="/static/elo.html?0#recent=2500000")
     v-alert(:value="true" color="info") {{ stats.client_24hr }} clients in past 24 hours, {{ stats.client_1hr }} in past hour.<br/>


### PR DESCRIPTION
Escaping the quotes leads to it being interpreted as a relative URL
instead.