### PR TITLE
Ignore test matches for graph rating and line

### DIFF
--- a/server.js
+++ b/server.js
@@ -1676,6 +1676,7 @@ app.get("/data/elograph.json", asyncMiddleware(async(req, res) => {
             // Force the match to show up as a test instead of the usual SPRT
             if (match.is_test) {
                 sprt = "TEST";
+                isBest = false;
             }
 
             // Save ratings of best networks
@@ -1704,7 +1705,7 @@ app.get("/data/elograph.json", asyncMiddleware(async(req, res) => {
                 net: Math.max(0.0, Number((info.net || item.net) + rating / 100000)),
                 sprt: info.sprt,
                 hash: item.hash.slice(0, 6),
-                best: item.best
+                best: item.best && info.sprt !== "TEST"
             });
 
             // Add additional result for multiple matches


### PR DESCRIPTION
r?@roy7 Fixes two issues: test match rating is saved for later computation and best line is used for all matches of promoted networks including tests.

Here's a screenshot of at least the latter issue:
![screen shot 2018-08-04 at 2 06 22 pm](https://user-images.githubusercontent.com/438537/43680435-a5a31c10-97ef-11e8-8c28-4e642bc380b2.png)
