### PR TITLE
Hide graph point for any matches against ELF instead of only ELF-vs-ELF

### DIFF
--- a/server.js
+++ b/server.js
@@ -1657,8 +1657,8 @@ app.get("/data/elograph.json", asyncMiddleware(async(req, res) => {
                 elo = CalculateEloFromPercent(fakewins / fakecount);
             }
 
-            // Hide ELF-vs-ELF test matches
-            if (ELF_NETWORKS.includes(match.network1) && ELF_NETWORKS.includes(match.network2)) {
+            // Hide *-vs-ELF test matches as there's no meaningful Elo reference
+            if (ELF_NETWORKS.includes(match.network2)) {
                 elo = 0;
             }
 


### PR DESCRIPTION
Fix #206 b75daf Test is squeezing the chart to a flat line

r?@roy7 Makes your ELF-vs-ELF hiding more general